### PR TITLE
Silence postgres logs

### DIFF
--- a/tmppg.go
+++ b/tmppg.go
@@ -1,9 +1,11 @@
 package tmppg
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/authenticvision/tmppg/util/logutil"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -11,10 +13,48 @@ import (
 	"time"
 )
 
-func makeCmd(args ...string) *exec.Cmd {
+type postgres struct {
+	stdout, stderr io.Writer
+}
+
+type Option func(pg *postgres)
+
+func newPostgres(opts ...Option) *postgres {
+	pg := &postgres{}
+	for _, opt := range opts {
+		opt(pg)
+	}
+	return pg
+}
+
+type slogOut struct {
+	logger *slog.Logger
+	level  slog.Level
+}
+
+func (s slogOut) Write(p []byte) (n int, err error) {
+	s.logger.Log(context.Background(), s.level, string(p))
+	return len(p), nil
+}
+
+func WithLogOutput(logger *slog.Logger, level slog.Level) Option {
+	return func(pg *postgres) {
+		pg.stdout = slogOut{logger.With(slog.String("output", "stdout")), level}
+		pg.stderr = slogOut{logger.With(slog.String("output", "stderr")), level}
+	}
+}
+
+func WithOutput(stdout, stderr io.Writer) Option {
+	return func(pg *postgres) {
+		pg.stdout = stdout
+		pg.stderr = stderr
+	}
+}
+
+func (pg *postgres) makeCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = pg.stdout
+	cmd.Stderr = pg.stderr
 	return cmd
 }
 
@@ -25,7 +65,8 @@ const (
 	pqPingNoAttempt  = 3
 )
 
-func WithPostgresql(fn func(socketDir string) error) error {
+func WithPostgresql(fn func(socketDir string) error, opts ...Option) error {
+	pg := newPostgres(opts...)
 	dir, err := os.MkdirTemp("", "tmppg")
 	if err != nil {
 		return fmt.Errorf("setup temporary directory: %w", err)
@@ -35,12 +76,12 @@ func WithPostgresql(fn func(socketDir string) error) error {
 			slog.Error("failed to remove temporary directory", logutil.Err(err))
 		}
 	}()
-	cmd := makeCmd("initdb", "-D", dir, "--no-sync", "--no-instructions")
+	cmd := pg.makeCmd("initdb", "-D", dir, "--no-sync", "--no-instructions")
 	if err := cmd.Run(); err != nil {
 		slog.Debug("initdb failed with arguments", slog.Any("args", cmd.Args), logutil.Err(err))
 		return fmt.Errorf("initdb: %w", err)
 	}
-	pgCmd := makeCmd("postgres", "-D", dir, "--listen_addresses=", "--unix_socket_directories="+dir, "--fsync=off", "--synchronous_commit=off", "--full_page_writes=off")
+	pgCmd := pg.makeCmd("postgres", "-D", dir, "--listen_addresses=", "--unix_socket_directories="+dir, "--fsync=off", "--synchronous_commit=off", "--full_page_writes=off")
 	if err := pgCmd.Start(); err != nil {
 		slog.Debug("postgres failed with arguments", slog.Any("args", pgCmd.Args), logutil.Err(err))
 		return fmt.Errorf("start postgres: %w", err)
@@ -73,7 +114,7 @@ func WithPostgresql(fn func(socketDir string) error) error {
 			return fmt.Errorf("postgres exited unexpectedly: %w", err)
 		case <-time.After(100 * time.Millisecond):
 		}
-		cmd := makeCmd("pg_isready", "-q", "-h", dir, "-d", "postgres")
+		cmd := pg.makeCmd("pg_isready", "-q", "-h", dir, "-d", "postgres")
 		err := cmd.Run()
 		var exitErr *exec.ExitError
 		if err == nil {
@@ -94,7 +135,7 @@ func WithPostgresql(fn func(socketDir string) error) error {
 // RunWithPostgresql runs the given command with a PostgreSQL instance available.
 // Connection information is available via the standard PG* environment variables.
 // See https://www.postgresql.org/docs/current/libpq-envars.html
-func RunWithPostgresql(args []string) error {
+func RunWithPostgresql(args []string, opts ...Option) error {
 	return WithPostgresql(func(socketDir string) error {
 		wrapped := exec.Command(args[0], args[1:]...)
 		wrapped.Stdout = os.Stdout
@@ -104,5 +145,5 @@ func RunWithPostgresql(args []string) error {
 			return fmt.Errorf("%v: %v", wrapped.Args, err)
 		}
 		return nil
-	})
+	}, opts...)
 }

--- a/tmppg.go
+++ b/tmppg.go
@@ -81,7 +81,7 @@ func WithPostgresql(fn func(socketDir string) error, opts ...Option) error {
 		slog.Debug("initdb failed with arguments", slog.Any("args", cmd.Args), logutil.Err(err))
 		return fmt.Errorf("initdb: %w", err)
 	}
-	pgCmd := pg.makeCmd("postgres", "-D", dir, "--listen_addresses=", "--unix_socket_directories="+dir, "--fsync=off", "--synchronous_commit=off", "--full_page_writes=off")
+	pgCmd := pg.makeCmd("postgres", "-D", dir, "--listen_addresses=", "--unix_socket_directories="+dir, "--fsync=off", "--synchronous_commit=off", "--full_page_writes=off", "--log_statement=all")
 	if err := pgCmd.Start(); err != nil {
 		slog.Debug("postgres failed with arguments", slog.Any("args", pgCmd.Args), logutil.Err(err))
 		return fmt.Errorf("start postgres: %w", err)

--- a/tmppg_test.go
+++ b/tmppg_test.go
@@ -8,8 +8,11 @@ import (
 )
 
 func TestRunWithPostgresql(t *testing.T) {
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	r := require.New(t)
-	err := RunWithPostgresql([]string{"psql", "-d", "postgres", "-c", "SELECT 1"})
+	err := RunWithPostgresql(
+		[]string{"psql", "-d", "postgres", "-c", "SELECT 1"},
+		WithLogOutput(log, slog.LevelInfo),
+	)
 	r.NoError(err)
 }


### PR DESCRIPTION
Allow redirecting postgres output to logs, but discard them by default.

At least during startup, logs writes from postgres often end in the middle of a line. Buffering the log output to break it nicely into lines might be something nice for later.
